### PR TITLE
Add warning options to CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,8 @@ libhdcd_la_LDFLAGS = -version-info @HDCD_LIBTOOL_VERSION@
 
 LDADD = libhdcd.la
 
+AM_CFLAGS = -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Werror=implicit-function-declaration -Werror=missing-prototypes
+
 bin_PROGRAMS = hdcd-detect
 
 hdcd_detect_SOURCES = \

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Simple API
 
 ### Declare and initialize
 
-    hdcd_simple_t ctx;
-    ctx = shdcd_new();
+    hdcd_simple_t *ctx = shdcd_new();
 
 ### Each frame
     

--- a/hdcd_simple.h
+++ b/hdcd_simple.h
@@ -35,29 +35,29 @@
 extern "C" {
 #endif
 
-typedef void* hdcd_simple_t;
+typedef struct hdcd_simple_t hdcd_simple_t;
 
 /** create a new hdcd_simple context */
-hdcd_simple_t shdcd_new();
+hdcd_simple_t *shdcd_new(void);
 /** process 16-bit samples (stored in 32-bit), interlaced stereo, 44100Hz */
-void shdcd_process(hdcd_simple_t ctx, int *samples, int count);
+void shdcd_process(hdcd_simple_t *ctx, int *samples, int count);
 /** on a song change or something, reset the decoding state */
-void shdcd_reset(hdcd_simple_t ctx);
+void shdcd_reset(hdcd_simple_t *ctx);
 /** free the context when finished */
-void shdcd_free(hdcd_simple_t ctx);
+void shdcd_free(hdcd_simple_t *ctx);
 
 
 /** is HDCD encoding detected? */
-int shdcd_detected(hdcd_simple_t ctx);
+int shdcd_detected(hdcd_simple_t *ctx);
 /** get a string with an HDCD detection summary */
-void shdcd_detect_str(hdcd_simple_t ctx, char *str, int maxlen); /* [256] should be enough */
+void shdcd_detect_str(hdcd_simple_t *ctx, char *str, int maxlen); /* [256] should be enough */
 
 
 /** set a logging callback or use the default (print to stderr) */
 typedef void (*hdcd_log_callback)(const void *priv, const char* fmt, va_list args);
-int shdcd_attach_logger(hdcd_simple_t ctx, hdcd_log_callback func, void *priv);
-void shdcd_default_logger(hdcd_simple_t ctx);
-void shdcd_detach_logger(hdcd_simple_t ctx);
+int shdcd_attach_logger(hdcd_simple_t *ctx, hdcd_log_callback func, void *priv);
+void shdcd_default_logger(hdcd_simple_t *ctx);
+void shdcd_detach_logger(hdcd_simple_t *ctx);
 
 
 #ifdef __cplusplus

--- a/tool/hdcd-detect.c
+++ b/tool/hdcd-detect.c
@@ -160,7 +160,7 @@ int main(int argc, char *argv[]) {
     hdcd_state_stereo_t state_stereo;
     hdcd_log_t logger;
     */
-    hdcd_simple_t ctx;
+    hdcd_simple_t *ctx;
     char dstr[256];
 
     int ver_match = hdcd_lib_version(&lv_major, &lv_minor);

--- a/tool/hdcd-detect.c
+++ b/tool/hdcd-detect.c
@@ -28,7 +28,7 @@
 int lv_major = HDCD_DECODE2_VER_MAJOR;
 int lv_minor = HDCD_DECODE2_VER_MINOR;
 
-void usage(const char* name) {
+static void usage(const char* name) {
     fprintf(stderr, "Usage:\n %s in.wav [out.wav]\n", name);
     fprintf(stderr, "    in.wav must be a s16, stereo, 44100Hz wav file\n");
     fprintf(stderr, "    out.wav will be s24; will not prompt for overwrite\n");
@@ -50,7 +50,7 @@ typedef struct {
     int data_size_loc;
 } wavw_t;
 
-int fwrite_int16el(int16_t v, FILE *fp) {
+static int fwrite_int16el(int16_t v, FILE *fp) {
     const uint8_t b[2] = {
         (uint16_t)v & 0xff,
         (uint16_t)v >> 8,
@@ -58,7 +58,7 @@ int fwrite_int16el(int16_t v, FILE *fp) {
     return fwrite(&b, 1, 2, fp);
 }
 
-int fwrite_int24el(int32_t v, FILE *fp) {
+static int fwrite_int24el(int32_t v, FILE *fp) {
     const uint8_t b[3] = {
         ((uint32_t)v >> 8) & 0xff,
         ((uint32_t)v >> 16) & 0xff,
@@ -67,7 +67,7 @@ int fwrite_int24el(int32_t v, FILE *fp) {
     return fwrite(&b, 1, 3, fp);
 }
 
-int fwrite_int32el(int32_t v, FILE *fp) {
+static int fwrite_int32el(int32_t v, FILE *fp) {
     const uint8_t b[4] = {
         (uint32_t)v & 0xff,
         ((uint32_t)v >> 8) & 0xff,
@@ -77,7 +77,7 @@ int fwrite_int32el(int32_t v, FILE *fp) {
     return fwrite(&b, 1, 4, fp);
 }
 
-wavw_t* wav_write_open(const char *file_name, int16_t bits_per_sample) {
+static wavw_t* wav_write_open(const char *file_name, int16_t bits_per_sample) {
     int16_t channels = 2;
     int32_t sample_rate = 44100;
 
@@ -117,7 +117,7 @@ wavw_t* wav_write_open(const char *file_name, int16_t bits_per_sample) {
     return wav;
 }
 
-int wav_write(wavw_t *wav, const int32_t *samples, int count) {
+static int wav_write(wavw_t *wav, const int32_t *samples, int count) {
     int i;
     size_t elw = 0;
 
@@ -131,7 +131,7 @@ int wav_write(wavw_t *wav, const int32_t *samples, int count) {
     wav->size += elw;
 }
 
-int wav_write_close(wavw_t *wav) {
+static int wav_write_close(wavw_t *wav) {
     if ( fseek(wav->fp, wav->length_loc, SEEK_SET) == 0)
         fwrite_int32el(wav->size + 44 - 8 , wav->fp);
     if ( fseek(wav->fp, wav->data_size_loc, SEEK_SET) == 0)


### PR DESCRIPTION
This revealed quite a few, so better have them enabled for further development.

I'm fixing those related to prototypes in this set, but not the other existing warnings of the -Wswitch, -Wsign-compare, -Wreturn-type kind.
