### PR TITLE
libtool: export only the public symbols in shared libraries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ libhdcd_la_SOURCES = src/hdcd_decode2.c src/hdcd_simple.c src/hdcd_libversion.c
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libhdcd.pc
 
-libhdcd_la_LDFLAGS = -version-info @HDCD_LIBTOOL_VERSION@
+libhdcd_la_LDFLAGS = -version-info @HDCD_LIBTOOL_VERSION@ -export-symbols-regex "^hdcd_"
 
 LDADD = libhdcd.la
 


### PR DESCRIPTION
The prevents the _hdcd\* and other internal symbols from being exported.
